### PR TITLE
LiveAgent - Footer branding updates

### DIFF
--- a/docs/login
+++ b/docs/login
@@ -152,7 +152,6 @@ zaius.event('pageview');
   </div>
 
   <div class="footer__nav">
-    &copy; A Modern Tribe Hootenanny <span>|</span> 
     <a href="https://theeventscalendar.com/terms">Terms</a>
     <span>|</span> 
     <a href="https://theeventscalendar.com/privacy-policy/">Privacy

--- a/docs/my_tickets
+++ b/docs/my_tickets
@@ -154,7 +154,6 @@ zaius.event('pageview');
   </div>
 
   <div class="footer__nav">
-    &copy; A Modern Tribe Hootenanny <span>|</span> 
     <a href="https://theeventscalendar.com/terms">Terms</a>
     <span>|</span> 
     <a href="https://theeventscalendar.com/privacy-policy/">Privacy

--- a/docs/submit_ticket
+++ b/docs/submit_ticket
@@ -153,7 +153,6 @@ zaius.event('pageview');
   </div>
 
   <div class="footer__nav">
-    &copy; A Modern Tribe Hootenanny <span>|</span> 
     <a href="https://theeventscalendar.com/terms">Terms</a>
     <span>|</span> 
     <a href="https://theeventscalendar.com/privacy-policy/">Privacy


### PR DESCRIPTION
Remove the Modern Tribe brand from LA footers, including my_tickets, login and submit_ticket pages.

![Screenshot from 2021-01-18 14-29-36](https://user-images.githubusercontent.com/15730971/104921601-d8607300-5999-11eb-94a4-920e9006a24c.png)


[TECCOM-1469]

[TECCOM-1469]: https://theeventscalendar.atlassian.net/browse/TECCOM-1469